### PR TITLE
ENH: Allow silent operation

### DIFF
--- a/pytest-cov/README.rst
+++ b/pytest-cov/README.rst
@@ -190,14 +190,20 @@ The terminal report with line numbers::
     TOTAL                  353     20    94%
 
 
-The remaining three reports output to files without showing anything on the terminal (useful for
-when the output is going to a continuous integration server)::
+These three report options output to files without showing anything on the terminal::
 
     py.test --cov-report html
             --cov-report xml
             --cov-report annotate
             --cov myproj tests/
 
+The final report option can also suppress printing to the terminal::
+
+    py.test --cov-report= tests/
+
+This mode can be especially useful on continuous integration servers, where a coverage file
+coverage file is needed for subsequent processing, but no local report needs to be viewed.
+For example, test run on Travis-CI could produce a .coverage file for use with Coveralls.
 
 Coverage Data File
 ------------------

--- a/pytest-cov/README.rst
+++ b/pytest-cov/README.rst
@@ -68,7 +68,7 @@ subprocesses.
 
 Running centralised testing::
 
-    py.test --cov myproj tests/
+    py.test --cov-source myproj tests/
 
 Shows a terminal report::
 
@@ -91,7 +91,7 @@ file system.  Each slave will have it's subprocesses measured.
 
 Running distributed testing with dist mode set to load::
 
-    py.test --cov myproj -n 2 tests/
+    py.test --cov-source myproj -n 2 tests/
 
 Shows a terminal report::
 
@@ -107,7 +107,7 @@ Shows a terminal report::
 
 Again but spread over different hosts and different directories::
 
-    py.test --cov myproj --dist load
+    py.test --cov-source myproj --dist load
             --tx ssh=memedough@host1//chdir=testenv1
             --tx ssh=memedough@host2//chdir=/tmp/testenv2//python=/tmp/env1/bin/python
             --rsyncdir myproj --rsyncdir tests --rsync examples
@@ -134,7 +134,7 @@ environments.
 
 Running distributed testing with dist mode set to each::
 
-    py.test --cov myproj --dist each
+    py.test --cov-source myproj --dist each
             --tx popen//chdir=/tmp/testenv3//python=/usr/local/python27/bin/python
             --tx ssh=memedough@host2//chdir=/tmp/testenv4//python=/tmp/env2/bin/python
             --rsyncdir myproj --rsyncdir tests --rsync examples
@@ -164,7 +164,7 @@ annotated source code.
 
 The terminal report without line numbers (default)::
 
-    py.test --cov-report term --cov myproj tests/
+    py.test --cov-report term --cov-source myproj tests/
 
     -------------------- coverage: platform linux2, python 2.6.4-final-0 ---------------------
     Name                 Stmts   Miss  Cover
@@ -178,7 +178,7 @@ The terminal report without line numbers (default)::
 
 The terminal report with line numbers::
 
-    py.test --cov-report term-missing --cov myproj tests/
+    py.test --cov-report term-missing --cov-source myproj tests/
 
     -------------------- coverage: platform linux2, python 2.6.4-final-0 ---------------------
     Name                 Stmts   Miss  Cover   Missing
@@ -195,15 +195,15 @@ These three report options output to files without showing anything on the termi
     py.test --cov-report html
             --cov-report xml
             --cov-report annotate
-            --cov myproj tests/
+            --cov-source myproj tests/
 
 The final report option can also suppress printing to the terminal::
 
-    py.test --cov-report= tests/
+    py.test --cov-report= --cov-source myproj tests/
 
 This mode can be especially useful on continuous integration servers, where a coverage file
-coverage file is needed for subsequent processing, but no local report needs to be viewed.
-For example, test run on Travis-CI could produce a .coverage file for use with Coveralls.
+is needed for subsequent processing, but no local report needs to be viewed. For example,
+tests run on Travis-CI could produce a .coverage file for use with Coveralls.
 
 Coverage Data File
 ------------------
@@ -224,7 +224,7 @@ For example if tests are contained within the directory tree being measured the 
 excluded if desired by using a .coveragerc file with the omit option set::
 
     py.test --cov-config .coveragerc
-            --cov myproj
+            --cov-source myproj
             myproj/tests/
 
 Where the .coveragerc file contains file globs::


### PR DESCRIPTION
I don't want my coverage reports to print on my CI targets, and using `--cov-report=html | xml` adds time overhead. This adds an option to suppress printing altogether. Let me know if this seems useful!