### PR TITLE
multiprocessing_start finalizer fix

### DIFF
--- a/cov-core/cov_core.py
+++ b/cov-core/cov_core.py
@@ -10,9 +10,10 @@ import os
 
 def multiprocessing_start(obj):
     cov = cov_core_init.init()
-    import multiprocessing.util
-    multiprocessing.util.Finalize(
-        None, multiprocessing_finish, args=(cov,), exitpriority=1000)
+    if cov is not None:
+        import multiprocessing.util
+        multiprocessing.util.Finalize(
+            None, multiprocessing_finish, args=(cov,), exitpriority=1000)
 
 
 def multiprocessing_finish(cov):


### PR DESCRIPTION
This fixes problems like this (when running `py.test` on a bunch of parallelized tests):
```python
Traceback (most recent call last)                               :
Traceback (most recent call last):
Traceback (most recent call last):
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
Traceback (most recent call last):
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
Traceback (most recent call last):
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
Traceback (most recent call last):
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
Traceback (most recent call last):
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
Traceback (most recent call last):
  File "env/lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
```