### PR TITLE
Remove MP Finalize if cov didnt initialize.

### DIFF
--- a/cov-core/cov_core.py
+++ b/cov-core/cov_core.py
@@ -10,9 +10,10 @@ import os
 
 def multiprocessing_start(obj):
     cov = cov_core_init.init()
-    import multiprocessing.util
-    multiprocessing.util.Finalize(
-        None, multiprocessing_finish, args=(cov,), exitpriority=1000)
+    if cov:
+        import multiprocessing.util
+        multiprocessing.util.Finalize(
+            None, multiprocessing_finish, args=(cov,), exitpriority=1000)
 
 
 def multiprocessing_finish(cov):


### PR DESCRIPTION
There may be cases where cov_core_init.init() returns None. 
Currently, multiprocessing_finish raises an AttributeError.
```
Traceback (most recent call last):
  File "/..../lib/python2.7/multiprocessing/util.py", line 274, in _run_finalizers
    finalizer()
  File "/.../lib/python2.7/multiprocessing/util.py", line 207, in __call__
    res = self._callback(*self._args, **self._kwargs)
  File "/.../lib/python2.7/site-packages/cov_core.py", line 19, in multiprocessing_finish
    cov.stop()
AttributeError: 'NoneType' object has no attribute 'stop'
```

It's a bit hard to reproduce with a unit test but i'm seeing the error when I run py.test with the `pytest-cov` plugin installed but not invoked 