### PR TITLE
Protect multiprocessing_finish against None coverage object.

### DIFF
--- a/cov-core/cov_core.py
+++ b/cov-core/cov_core.py
@@ -16,8 +16,9 @@ def multiprocessing_start(obj):
 
 
 def multiprocessing_finish(cov):
-    cov.stop()
-    cov.save()
+    if cov is not None:
+        cov.stop()
+        cov.save()
 
 
 try:


### PR DESCRIPTION
Hi,

The `cov` parameter of the `multiprocessing_finish` hook is given by the `multiprocessing_start` function that calls `cov_core_init.init()`. This init function can return a `None` value if it fails with an exception (ignores it and moves on) or the environment is not configured properly (doesn't create a coverage object).

This protects the hook from calling the `stop` and `save` function on a `None` value. Another part of the fix might be to warn when the coverage environment configuration is not set, instead of ignoring.