### PR TITLE
Don't bother adding finalizer if no coverage object was created

### DIFF
--- a/cov-core/cov_core.py
+++ b/cov-core/cov_core.py
@@ -10,9 +10,10 @@ import os
 
 def multiprocessing_start(obj):
     cov = cov_core_init.init()
-    import multiprocessing.util
-    multiprocessing.util.Finalize(
-        None, multiprocessing_finish, args=(cov,), exitpriority=1000)
+    if cov:
+        import multiprocessing.util
+        multiprocessing.util.Finalize(
+            None, multiprocessing_finish, args=(cov,), exitpriority=1000)
 
 
 def multiprocessing_finish(cov):


### PR DESCRIPTION
There's no need to stop and save the coverage object if one wasn't created.