### PR TITLE
Avoid warning about missing coverage data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 * Support for coverage 4.0.
 * Data file suffixing changed to use coverage's ``data_suffix=True`` option (instead of the
   custom suffixing).
+* Avoid warning about missing coverage data (just like ``coverage.control.process_startup``).
 
 1.8.2 (2014-11-06)
 ------------------

--- a/src/pytest_cov/embed.py
+++ b/src/pytest_cov/embed.py
@@ -58,4 +58,6 @@ def init():
                                 auto_data=True)
         cov.erase()
         cov.start()
+        cov._warn_no_data = False
+        cov._warn_unimported_source = False
         return cov


### PR DESCRIPTION
(just like ``coverage.control.process_startup``).

Now that the `.pth` install works so well we can get these benign "No data was collected" warnings all over the plate. They are quite annoying if you do assertions on subprocess output.