### PR TITLE
Remove placeholder pages and add a release process.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,9 +8,8 @@ Contents:
 
    readme
    installation
-   usage
-   reference/index
    contributing
+   releasing
    authors
    changelog
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,7 +1,0 @@
-Reference
-=========
-
-.. toctree::
-    :glob:
-
-    pytest_cov*

--- a/docs/reference/pytest_cover.rst
+++ b/docs/reference/pytest_cover.rst
@@ -1,5 +1,0 @@
-pytest_cov
-=============================
-
-.. automodule:: pytest_cov
-    :members:

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -1,0 +1,34 @@
+=========
+Releasing
+=========
+
+The process for releasing should follow these steps:
+
+#. Test that docs build and render properly by running ``tox -e docs,spell``.
+
+   If there are bogus spelling issues add the words in ``spelling_wordlist.txt``.
+#. Update ``CHANGELOG.rst`` and ``AUTHORS.rst`` to be up to date.
+#. Bump the version by running ``bumpversion [ major | minor | patch ]``. This will automatically add a tag.
+
+   Alternativelly, you can manually edit the files and run ``git tag v1.2.3`` yourself.
+#. Push changes and tags with::
+
+    git push
+    git push --tags
+#. Wait for `AppVeyor <https://ci.appveyor.com/project/schlamar/pytest-cov>`_
+   and `Travis <https://travis-ci.org/schlamar/pytest-cov>`_ to give the green builds.
+#. Check that the docs on `ReadTheDocs <https://readthedocs.org/projects/pytest-cov>`_ are built.
+#. Make sure you have a clean checkout, run ``git status`` to verify.
+#. Manually clean temporary files (that are ignored and won't show up in ``git status``)::
+
+        rm -rf dist build src/*.egg-info
+
+   These files need to be removed to force distutils/setuptools to rebuild everything and recreate the egg-info metadata.
+#. Build the dists::
+
+        python3.4 setup.py clean --all sdist bdist_wheel
+
+#. Verify that the resulting archives (found in ``dist/``) are good.
+#. Upload the sdist and wheel with twine::
+
+    twine upload dist/*

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,0 @@
-=====
-Usage
-=====
-
-To use pytest-cov in a project::
-
-	import pytest_cov

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     {2.7,docs}: {env:TOXPYTHON:python2.7}
     3.3: {env:TOXPYTHON:python3.3}
     3.4: {env:TOXPYTHON:python3.4}
-    {clean,check,report,extension-coveralls,coveralls}: python3.4
+    {clean,check,report,extension-coveralls,coveralls,spell}: python3.4
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
Ref #60.

Post-release process intentionally left out. I need to check how easy is to "dev-bump" with bumpversion (eg: v1.2.3 to v1.2.4dev)